### PR TITLE
Updates to support Hub 4.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: java
+sudo: false
+install: true
+
+jdk:
+  - oraclejdk8
+
+  notifications:
+    email:
+      recipients:
+        - ybronshteyn@blackducksoftware.com
+  
+script:
+  ./gradlew build
+
+after_success:
+  - bash <(curl -s https://copilot.blackducksoftware.com/ci/travis/scripts/upload)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ install: true
 jdk:
   - oraclejdk8
 
-  notifications:
-    email:
-      recipients:
-        - ybronshteyn@blackducksoftware.com
+notifications:
+  email:
+    recipients:
+      - ybronshteyn@blackducksoftware.com
   
 script:
   ./gradlew build


### PR DESCRIPTION
- Latest version of [Hub-Detect](https://github.com/blackducksoftware/hub-detect) (3.1.0)
- Latest version of Concourse (3.9.2)
- Updating transitive dependencies